### PR TITLE
Fix: uiSchema UI splitButton optimization

### DIFF
--- a/src/extends/Structs/index.tsx
+++ b/src/extends/Structs/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, Icon, Field, Button, SplitButton } from '@b-design/ui';
+import { Form, Icon, Field, Button } from '@b-design/ui';
 import { If } from 'tsx-control-statements/components';
 import type { UIParam, GroupOption } from '../../interface/application';
 import UISchema from '../../components/UISchema';
@@ -216,17 +216,19 @@ class Structs extends React.Component<Props, State> {
               Add
             </Button>
           </If>
+
           <If condition={parameterGroupOption.length !== 0}>
-            <SplitButton label="Add" type="secondary" autoWidth={false}>
+            <Button.Group>
               {parameterGroupOption?.map((item) => (
-                <SplitButton.Item
+                <Button
+                  type="secondary"
                   key={item.keys.join(',')}
                   onClick={() => this.addStructPlanItem(item)}
                 >
                   {item.label || item.keys.join(':')}
-                </SplitButton.Item>
+                </Button>
               ))}
-            </SplitButton>
+            </Button.Group>
           </If>
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: wb-wb665667 <wb-wb665667@alibaba-inc.com>

### Description of your changes

Fixes #289 uiSchema UI bug fix

I have:
- [x]  Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

Click callback is not implemented on the left side of SplitButton. Now use the Button group to optimize
![image](https://user-images.githubusercontent.com/21334770/147105197-794ed490-7863-4cba-9da9-7618f2fba3bb.png)

