### PR TITLE
Fix: terminated workflow's suspend status is incorrect

### DIFF
--- a/src/layout/Application/components/WorkflowStep/index.tsx
+++ b/src/layout/Application/components/WorkflowStep/index.tsx
@@ -123,7 +123,7 @@ class WorkflowStep extends Component<Props, State> {
       { name: 'running', value: 'running', iconType: '' },
     ];
     const find = stepStatus.find((item) => {
-      if (item.name === steps[index].phase) {
+      if (item.name === steps[index].phase && steps[index].type != 'suspend') {
         return item;
       }
     }) || {

--- a/src/layout/Application/components/WorkflowStep/index.tsx
+++ b/src/layout/Application/components/WorkflowStep/index.tsx
@@ -122,14 +122,22 @@ class WorkflowStep extends Component<Props, State> {
       { name: 'stopped', value: 'stopped', iconType: 'warning' },
       { name: 'running', value: 'running', iconType: '' },
     ];
-    const find = stepStatus.find((item) => {
-      if (item.name === steps[index].phase && steps[index].type != 'suspend') {
-        return item;
-      }
-    }) || {
-      value: 'stopped',
-      iconType: '',
-    };
+    let find;
+    if (recordItem.status === 'terminated' && steps[index].type === 'suspend') {
+      find = {
+        value: 'stopped',
+        iconType: '',
+      };
+    } else {
+      find = stepStatus.find((item) => {
+        if (item.name === steps[index].phase) {
+          return item;
+        }
+      }) || {
+        value: 'stopped',
+        iconType: '',
+      };
+    }
 
     const isAnimate = find && find.value === 'running' ? 'shanshan' : '';
 


### PR DESCRIPTION
Signed-off-by: wb-wb665667 <wb-wb665667@alibaba-inc.com>

### Description of your changes

Fixes #318 terminated workflow's suspend status is incorrect

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

![image](https://user-images.githubusercontent.com/21334770/148163069-57b1d0f0-d6c7-476c-ad2e-a3c65f0cc8d7.png)

