### PR TITLE
Fix: make link text in the description of a parameter to by a superlink

### DIFF
--- a/src/components/UISchema/index.tsx
+++ b/src/components/UISchema/index.tsx
@@ -15,7 +15,7 @@ import K8sObjectsCode from '../../extends/K8sObjectsCode';
 import type { Rule } from '@alifd/field';
 import KV from '../../extends/KV';
 import './index.less';
-import { checkImageName } from '../../utils/common';
+import { checkImageName, replaceUrl } from '../../utils/common';
 import locale from '../../utils/locale';
 import HelmValues from '../../extends/HelmValues';
 
@@ -207,7 +207,9 @@ class UISchema extends Component<Props, State> {
               labelAlign={inline ? 'inset' : 'left'}
               label={param.label}
               key={param.jsonKey}
-              help={param.description}
+              help={
+                <div dangerouslySetInnerHTML={{ __html: replaceUrl(param.description || '') }} />
+              }
               disabled={param.disable}
             >
               <Input
@@ -225,7 +227,9 @@ class UISchema extends Component<Props, State> {
               labelAlign={inline ? 'inset' : 'left'}
               label={param.label}
               key={param.jsonKey}
-              help={param.description}
+              help={
+                <div dangerouslySetInnerHTML={{ __html: replaceUrl(param.description || '') }} />
+              }
               disabled={param.disable}
             >
               <Input

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -137,3 +137,11 @@ export const ACKCLusterStatus = [
     color: '#ef1111',
   },
 ];
+
+export const replaceUrl = function (text: string) {
+  const re = /(http[s]?:\/\/([\w-]+.)+([:\d+])?(\/[\w-\.\/\?%&=]*)?)/gi;
+  const str = text.replace(re, function (a) {
+    return '<a href="' + a + '" target=_blank>' + a + '</a>';
+  });
+  return str;
+};


### PR DESCRIPTION
Signed-off-by: wb-wb665667 <wb-wb665667@alibaba-inc.com>

### Description of your changes

Fixes #288 make link text in the description of a parameter to by a superlink

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

![image](https://user-images.githubusercontent.com/21334770/148197250-c3a32850-fa42-4c33-8233-cd3147e3b073.png)

