### PR TITLE
Fix: create cluster add addon message show

### DIFF
--- a/src/interface/addon.ts
+++ b/src/interface/addon.ts
@@ -8,11 +8,12 @@ export interface Addon {
   detail?: string;
   tags?: string[];
   createTime?: string;
-  deployTo?: { controlPlane: boolean; runtimeCluster: boolean };
+  deployTo?: { controlPlane: boolean; runtimeCluster: boolean; runtime_cluster: boolean };
   dependencies?: { name: string }[];
   definitions?: Definition[];
   uiSchema?: UIParam[];
   registryName?: string;
+  url?: string;
 }
 
 export interface AddonStatus {

--- a/src/pages/Cluster/components/CloudServiceDialog/index.tsx
+++ b/src/pages/Cluster/components/CloudServiceDialog/index.tsx
@@ -14,7 +14,8 @@ type Props = {
   setVisible: (visible: boolean) => void;
   setCloudService: (isCloudService: boolean) => void;
   t: (key: string) => string;
-  dispatch: ({}) => void;
+  onPropsOK: () => void;
+  dispatch: ({ }) => void;
 };
 
 type State = {
@@ -76,6 +77,7 @@ class CloudServiceDialog extends React.Component<Props, State> {
         .then((re) => {
           if (re) {
             this.setState({ choseInput: false, cloudClusters: re.clusters, btnLoading: false });
+            this.props.onPropsOK();
           }
         })
         .catch((err) => {
@@ -122,7 +124,7 @@ class CloudServiceDialog extends React.Component<Props, State> {
           });
         }
       })
-      .then(() => {});
+      .then(() => { });
   };
 
   render() {

--- a/src/pages/Cluster/index.tsx
+++ b/src/pages/Cluster/index.tsx
@@ -117,7 +117,6 @@ class Cluster extends React.Component<Props, State> {
     return (addonMessage || []).map((item) => {
       return (
         <span>
-          {' '}
           <a href={item.path}> {item.name} </a> 、
         </span>
       );

--- a/src/pages/Cluster/index.tsx
+++ b/src/pages/Cluster/index.tsx
@@ -16,7 +16,7 @@ type Props = {
   clusterList: [];
   defaultCluster: string;
   cloudClusters: [];
-  dispatch: ({}) => {};
+  dispatch: ({ }) => {};
 };
 
 type State = {
@@ -114,14 +114,23 @@ class Cluster extends React.Component<Props, State> {
 
   showAddonMessage() {
     const { addonMessage } = this.state;
-    return (addonMessage || []).map((item) => {
+    return (addonMessage || []).map((item, index, arr) => {
+      const lastIndex = arr.length - 1;
+      const showSymbol = index === lastIndex ? '' : '、';
       return (
         <span>
-          <a href={item.path}> {item.name} </a> 、
+          <a href={item.path}>
+            {item.name}
+            {showSymbol}
+          </a>
         </span>
       );
     });
   }
+
+  handleHiddenAddonMessage = () => {
+    this.setState({ isShowAddonMessage: false });
+  };
 
   render() {
     const { clusterList = [], dispatch } = this.props;
@@ -158,7 +167,7 @@ class Cluster extends React.Component<Props, State> {
         />
 
         <If condition={isShowAddonMessage && addonMessage.length != 0}>
-          <Message type="notice">
+          <Message type="notice" closeable onClose={this.handleHiddenAddonMessage}>
             Connect Cluster Success! Please upgrade {this.showAddonMessage()} addons, make them take
             effect in the new cluster.
           </Message>
@@ -187,6 +196,9 @@ class Cluster extends React.Component<Props, State> {
               }}
               setCloudService={(visible) => {
                 this.setState({ showAddCloudCluster: visible });
+              }}
+              onPropsOK={() => {
+                this.onGetEnabledAddon();
               }}
               dispatch={dispatch}
             />

--- a/src/pages/Cluster/index.tsx
+++ b/src/pages/Cluster/index.tsx
@@ -9,6 +9,8 @@ import { Button, Message } from '@b-design/ui';
 import { deleteCluster } from '../../api/cluster';
 import Translation from '../../components/Translation';
 import { If } from 'tsx-control-statements/components';
+import { getEnabledAddons, getAddonsList } from '../../api/addons';
+import { Addon } from '../../interface/addon';
 
 type Props = {
   clusterList: [];
@@ -24,6 +26,8 @@ type State = {
   showAddCluster: boolean;
   showAddCloudCluster: boolean;
   editClusterName: string;
+  addonMessage: { name: string; path: string }[];
+  isShowAddonMessage: boolean;
 };
 
 @connect((store: any) => {
@@ -39,6 +43,8 @@ class Cluster extends React.Component<Props, State> {
       showAddCluster: false,
       showAddCloudCluster: false,
       editClusterName: '',
+      addonMessage: [],
+      isShowAddonMessage: false,
     };
   }
 
@@ -78,10 +84,58 @@ class Cluster extends React.Component<Props, State> {
     });
   };
 
+  onGetEnabledAddon = async () => {
+    getEnabledAddons({}).then((res) => {
+      this.onGetAddonsList(res.enabledAddons);
+    });
+  };
+
+  onGetAddonsList = async (enableAddon: { name: string; phase: boolean }[]) => {
+    getAddonsList({}).then((res) => {
+      const addonMessage: { name: string; path: string }[] = [];
+      const addonList: Addon[] = res.addons;
+      (enableAddon || []).forEach((ele: { name: string; phase: boolean }) => {
+        addonList.forEach((item: Addon) => {
+          const isMatchName = ele.name === item.name;
+          const deploy = item.deployTo || { runtimeCluster: false, runtime_cluster: false };
+          if (isMatchName && (deploy.runtimeCluster || deploy.runtime_cluster)) {
+            addonMessage.push({ name: item.name, path: item.url || '' });
+          }
+        });
+      });
+      if (addonMessage && addonMessage.length !== 0) {
+        this.setState({
+          isShowAddonMessage: true,
+          addonMessage: addonMessage,
+        });
+      }
+    });
+  };
+
+  showAddonMessage() {
+    const { addonMessage } = this.state;
+    return (addonMessage || []).map((item) => {
+      return (
+        <span>
+          {' '}
+          <a href={item.path}> {item.name} </a> 、
+        </span>
+      );
+    });
+  }
+
   render() {
     const { clusterList = [], dispatch } = this.props;
-    const { page, pageSize, query, showAddCluster, showAddCloudCluster, editClusterName } =
-      this.state;
+    const {
+      page,
+      pageSize,
+      query,
+      showAddCluster,
+      showAddCloudCluster,
+      editClusterName,
+      isShowAddonMessage,
+      addonMessage,
+    } = this.state;
     return (
       <div>
         <Title
@@ -103,6 +157,14 @@ class Cluster extends React.Component<Props, State> {
             </Button>,
           ]}
         />
+
+        <If condition={isShowAddonMessage && addonMessage.length != 0}>
+          <Message type="notice">
+            Connect Cluster Success! Please upgrade {this.showAddonMessage()} addons, make them take
+            effect in the new cluster.
+          </Message>
+        </If>
+
         <SelectSearch
           dispatch={dispatch}
           getChildCompentQuery={(q: string): any => {
@@ -143,6 +205,7 @@ class Cluster extends React.Component<Props, State> {
               }}
               onOK={() => {
                 this.getClusterList();
+                this.onGetEnabledAddon();
                 this.setState({ showAddCluster: false, editClusterName: '' });
               }}
               dispatch={dispatch}


### PR DESCRIPTION
Signed-off-by: wb-wb665667 <wb-wb665667@alibaba-inc.com>

### Description of your changes

Fixes #320 create cluster add addon message show

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer
![image](https://user-images.githubusercontent.com/21334770/154035113-d3feb97c-9771-4f1e-9696-4b338e1fe4bc.png)
1.dunhao Display Optimization
2.add Message closed 
3.When creating a cluster in two cases, addon information is displayed according to conditions