### PR TITLE
Feat: support show the prompt message by the trait podDisruptive value

### DIFF
--- a/src/interface/application.ts
+++ b/src/interface/application.ts
@@ -303,3 +303,15 @@ export interface ApplicationComponentConfig {
   properties: any;
   traits?: Trait[];
 }
+
+export interface DefinitionBase {
+  name: string;
+  description?: string;
+  icon?: string;
+  trait?: TraitDefinitionSpec;
+}
+
+export interface TraitDefinitionSpec {
+  podDisruptive?: boolean;
+  appliesToWorkloads?: string[];
+}

--- a/src/locals/Zh/zh.json
+++ b/src/locals/Zh/zh.json
@@ -432,5 +432,6 @@
   "Components": "组件",
   "Component": "组件",
   "Component Selector": "根据组件筛选",
-  "Component Basic Info": "组件基础信息"
+  "Component Basic Info": "组件基础信息",
+  "This trait properties change will cause pod restart after the application deploy": "该类型运维特征参数变更将导致应用重新部署时重启 Pod 实例。"
 }

--- a/src/pages/ApplicationConfig/components/Components/index.less
+++ b/src/pages/ApplicationConfig/components/Components/index.less
@@ -38,6 +38,7 @@
     cursor: pointer;
     svg {
       width: 30px;
+      min-width: 30px;
       height: 30px;
       margin-right: 4px;
     }

--- a/src/pages/ApplicationConfig/components/Components/index.tsx
+++ b/src/pages/ApplicationConfig/components/Components/index.tsx
@@ -65,7 +65,7 @@ class ComponentsList extends Component<Props> {
                   {item.traits?.map((trait) => {
                     const label = trait.alias ? trait.alias + '(' + trait.type + ')' : trait.type;
                     return (
-                      <Col xs={12} l={8} key={trait.type}>
+                      <Col xs={24} l={12} key={trait.type}>
                         <div
                           onClick={() => this.props.changeTraitStats(true, trait, item.name)}
                           className="trait-icon"


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

Fixes #395

![image](https://user-images.githubusercontent.com/18493394/158566674-cbade16a-1d9c-414a-be96-47d5fd2045d2.png)


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.