### PR TITLE
Feat: support the conditions for ui schema and add some extend components about helm

### DIFF
--- a/src/api/productionLink.ts
+++ b/src/api/productionLink.ts
@@ -9,3 +9,4 @@ export const project = `/api/v1/projects`;
 export const targetURL = `/api/v1/targets`;
 export const envURL = `/api/v1/envs`;
 export const payloadTypeURL = `/api/v1/payload_types`;
+export const repository = '/api/v1/repository';

--- a/src/api/repository.ts
+++ b/src/api/repository.ts
@@ -1,0 +1,33 @@
+import { get } from './request';
+import { repository } from './productionLink';
+import { getDomain } from '../utils/common';
+
+const baseURLOject = getDomain();
+const baseURL = baseURLOject.APIBASE;
+
+export function getChartValues(params: {
+  url: string;
+  repoType: string;
+  chart: string;
+  version: string;
+}) {
+  const url =
+    baseURL + repository + '/charts/' + params.chart + '/versions/' + params.version + '/values';
+  return get(url, { params: { repoUrl: params.url, repoType: params.repoType } }).then(
+    (res) => res,
+  );
+}
+
+export function getCharts(params: { url: string; repoType: string }) {
+  const url = baseURL + repository + '/charts';
+  return get(url, { params: { repoUrl: params.url, repoType: params.repoType } }).then(
+    (res) => res,
+  );
+}
+
+export function getChartVersions(params: { url: string; repoType: string; chart: string }) {
+  const url = baseURL + repository + '/charts/' + params.chart + '/versions';
+  return get(url, { params: { repoUrl: params.url, repoType: params.repoType } }).then(
+    (res) => res,
+  );
+}

--- a/src/components/UISchema/index.tsx
+++ b/src/components/UISchema/index.tsx
@@ -448,6 +448,7 @@ class UISchema extends Component<Props, State> {
               >
                 <HelmRepoSelect
                   disabled={disableEdit}
+                  helm={this.props.value}
                   {...init(param.jsonKey, {
                     initValue: initValue,
                     rules: [

--- a/src/extends/Group/index.tsx
+++ b/src/extends/Group/index.tsx
@@ -85,7 +85,6 @@ class Group extends React.Component<Props, State> {
       disableAddon = false,
     } = this.props;
     const { closed, enable, checked } = this.state;
-    console.log(title, closed);
     return (
       <Loading visible={loading || false} style={{ width: '100%' }}>
         <div className="group-container">

--- a/src/extends/Group/index.tsx
+++ b/src/extends/Group/index.tsx
@@ -58,7 +58,7 @@ class Group extends React.Component<Props, State> {
     if (findKey || alwaysShow) {
       this.setState({ enable: true, closed: false, checked: true });
     } else if (required) {
-      this.setState({ enable: true, closed: closed, checked: true });
+      this.setState({ enable: true, closed: false, checked: true });
     } else {
       this.setState({ enable: false, closed: closed, checked: false });
     }

--- a/src/extends/HelmChartSelect/index.tsx
+++ b/src/extends/HelmChartSelect/index.tsx
@@ -1,0 +1,92 @@
+import React, { Component } from 'react';
+import { getCharts } from '../../api/repository';
+import { Loading, Select } from '@b-design/ui';
+import i18n from '../../i18n';
+import locale from '../../utils/locale';
+
+type Props = {
+  value?: any;
+  onChange: (value: any) => void;
+  id: string;
+  disabled: boolean;
+  helm?: {
+    url: string;
+    repoType: string;
+  };
+};
+
+type State = {
+  charts?: string[];
+  loading: boolean;
+  inputChart: string;
+  helm?: {
+    url: string;
+    repoType: string;
+  };
+};
+
+class HelmChartSelect extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      loading: false,
+      inputChart: '',
+    };
+  }
+  componentDidMount() {
+    this.loadCharts();
+  }
+
+  loadCharts = () => {
+    const { helm } = this.props;
+    if (helm?.url && (!this.state.loading || this.state.helm?.url != helm.url)) {
+      this.setState({ loading: true, helm: helm });
+      getCharts(helm).then((re: string[]) => {
+        this.setState({ charts: re || [], loading: false, helm: helm });
+      });
+    }
+  };
+
+  onSearch = (value: string) => {
+    this.setState({ inputChart: value });
+  };
+
+  render() {
+    const { disabled, value, onChange, helm } = this.props;
+    const { charts, loading, helm: stateHelm, inputChart } = this.state;
+    if (helm?.url != stateHelm?.url) {
+      this.loadCharts();
+    }
+    const dataSource = (charts || []).map((item) => {
+      return {
+        label: item,
+        value: item,
+      };
+    });
+
+    if (inputChart) {
+      dataSource.unshift({
+        label: inputChart,
+        value: inputChart,
+      });
+    }
+
+    return (
+      <Loading visible={loading} style={{ width: '100%' }}>
+        <Select
+          placeholder={i18n.t('Please select or input a chart name')}
+          onChange={onChange}
+          showSearch={true}
+          onSearch={this.onSearch}
+          followTrigger={true}
+          disabled={disabled}
+          value={value}
+          dataSource={dataSource}
+          locale={locale.Select}
+        />
+      </Loading>
+    );
+  }
+}
+
+export default HelmChartSelect;

--- a/src/extends/HelmChartSelect/index.tsx
+++ b/src/extends/HelmChartSelect/index.tsx
@@ -40,9 +40,13 @@ class HelmChartSelect extends Component<Props, State> {
   loadCharts = () => {
     const { helm } = this.props;
     if (helm?.url && (!this.state.loading || this.state.helm?.url != helm.url)) {
+      // Reset chart value
+      if (this.state.helm) {
+        this.props.onChange('');
+      }
       this.setState({ loading: true, helm: helm });
       getCharts(helm).then((re: string[]) => {
-        this.setState({ charts: re || [], loading: false, helm: helm });
+        this.setState({ charts: re && Array.isArray(re) ? re : [], loading: false, helm: helm });
       });
     }
   };

--- a/src/extends/HelmChartVersionSelect/index.tsx
+++ b/src/extends/HelmChartVersionSelect/index.tsx
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+import { getChartVersions } from '../../api/repository';
+import { Loading, Select } from '@b-design/ui';
+import type { ChartVersion } from '../../interface/application';
+import i18n from '../../i18n';
+import locale from '../../utils/locale';
+
+type Props = {
+  value?: any;
+  onChange: (value: any) => void;
+  id: string;
+  disabled: boolean;
+  helm?: {
+    url: string;
+    repoType: string;
+    chart: string;
+  };
+};
+
+type State = {
+  versions?: ChartVersion[];
+  loading: boolean;
+  inputChartVersion: string;
+  helm?: {
+    url: string;
+    repoType: string;
+    chart: string;
+  };
+};
+
+class HelmChartVersionSelect extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      loading: false,
+      inputChartVersion: '',
+    };
+  }
+  componentDidMount() {
+    this.loadChartVersions();
+  }
+
+  loadChartVersions = () => {
+    const { helm } = this.props;
+    if (
+      helm?.url &&
+      helm.chart &&
+      !this.state.loading &&
+      helm.url == this.state.helm?.url &&
+      helm.chart == this.state.helm.chart
+    ) {
+      this.setState({ loading: true, helm: helm });
+      getChartVersions(helm).then((re: { versions: ChartVersion[] }) => {
+        if (re) {
+          this.setState({ versions: re.versions, loading: false, helm: helm });
+        }
+      });
+    }
+  };
+
+  onSearch = (value: string) => {
+    this.setState({ inputChartVersion: value });
+  };
+
+  render() {
+    const { disabled, value, onChange, helm } = this.props;
+    const { versions, loading, helm: stateHelm, inputChartVersion } = this.state;
+    if (helm?.url != stateHelm?.url || helm?.chart != stateHelm?.chart) {
+      this.loadChartVersions();
+    }
+    const dataSource =
+      versions?.map((version) => {
+        return {
+          label: version.version,
+          value: version.version,
+        };
+      }) || [];
+    if (inputChartVersion) {
+      dataSource.unshift({ label: inputChartVersion, value: inputChartVersion });
+    }
+    return (
+      <Loading visible={loading} style={{ width: '100%' }}>
+        <Select
+          placeholder={i18n.t('Please select or input a chart version')}
+          onChange={onChange}
+          onSearch={this.onSearch}
+          showSearch={true}
+          followTrigger={true}
+          disabled={disabled}
+          value={value}
+          dataSource={dataSource}
+          locale={locale.Select}
+        />
+      </Loading>
+    );
+  }
+}
+
+export default HelmChartVersionSelect;

--- a/src/extends/HelmChartVersionSelect/index.tsx
+++ b/src/extends/HelmChartVersionSelect/index.tsx
@@ -46,13 +46,16 @@ class HelmChartVersionSelect extends Component<Props, State> {
       helm?.url &&
       helm.chart &&
       !this.state.loading &&
-      helm.url == this.state.helm?.url &&
-      helm.chart == this.state.helm.chart
+      (helm.url != this.state.helm?.url || helm.chart != this.state.helm.chart)
     ) {
       this.setState({ loading: true, helm: helm });
+      // Reset version value
+      if (this.state.helm) {
+        this.props.onChange('');
+      }
       getChartVersions(helm).then((re: { versions: ChartVersion[] }) => {
         if (re) {
-          this.setState({ versions: re.versions, loading: false, helm: helm });
+          this.setState({ versions: re.versions || [], loading: false, helm: helm });
         }
       });
     }

--- a/src/extends/HelmRepoSelect/index.tsx
+++ b/src/extends/HelmRepoSelect/index.tsx
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import { Loading, Select } from '@b-design/ui';
+import i18n from '../../i18n';
+import locale from '../../utils/locale';
+
+type Props = {
+  value?: any;
+  onChange: (value: any) => void;
+  id: string;
+  disabled: boolean;
+};
+
+type State = {
+  repos: string[];
+  inputRepo: string;
+  loading: boolean;
+};
+
+class HelmRepoSelect extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      loading: false,
+      repos: [
+        'https://charts.bitnami.com/bitnami',
+        'https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core',
+      ],
+      inputRepo: '',
+    };
+  }
+  componentDidMount() {}
+
+  onSearch = (value: string) => {
+    this.setState({ inputRepo: value });
+  };
+  render() {
+    const { disabled, value, onChange } = this.props;
+    const { repos, loading, inputRepo } = this.state;
+    const dataSource = Array.from(repos);
+    if (inputRepo) {
+      dataSource.unshift(inputRepo);
+    }
+    return (
+      <Loading visible={loading} style={{ width: '100%' }}>
+        <Select
+          placeholder={i18n.t('Please select or input your owner helm repo')}
+          onChange={onChange}
+          inputMode="url"
+          disabled={disabled}
+          showSearch={true}
+          onSearch={this.onSearch}
+          followTrigger={true}
+          value={value}
+          dataSource={dataSource}
+          locale={locale.Select}
+        />
+      </Loading>
+    );
+  }
+}
+
+export default HelmRepoSelect;

--- a/src/extends/HelmRepoSelect/index.tsx
+++ b/src/extends/HelmRepoSelect/index.tsx
@@ -8,6 +8,7 @@ type Props = {
   onChange: (value: any) => void;
   id: string;
   disabled: boolean;
+  helm?: { repoType: string };
 };
 
 type State = {
@@ -21,14 +22,21 @@ class HelmRepoSelect extends Component<Props, State> {
     super(props);
     this.state = {
       loading: false,
-      repos: [
-        'https://charts.bitnami.com/bitnami',
-        'https://kubevelacharts.oss-cn-hangzhou.aliyuncs.com/core',
-      ],
+      repos: [],
       inputRepo: '',
     };
   }
-  componentDidMount() {}
+  componentDidMount() {
+    if (this.props.helm?.repoType == 'helm') {
+      this.onLoadRepos();
+    }
+  }
+
+  onLoadRepos = () => {
+    this.setState({
+      repos: ['https://charts.bitnami.com/bitnami', 'https://charts.kubevela.net/core'],
+    });
+  };
 
   onSearch = (value: string) => {
     this.setState({ inputRepo: value });
@@ -39,6 +47,9 @@ class HelmRepoSelect extends Component<Props, State> {
     const dataSource = Array.from(repos);
     if (inputRepo) {
       dataSource.unshift(inputRepo);
+    }
+    if (this.props.helm?.repoType == 'helm' && dataSource.length == 0) {
+      this.onLoadRepos();
     }
     return (
       <Loading visible={loading} style={{ width: '100%' }}>

--- a/src/extends/HelmValues/index.tsx
+++ b/src/extends/HelmValues/index.tsx
@@ -77,7 +77,7 @@ class HelmValues extends Component<Props, State> {
     const { helm } = this.props;
     if (helm?.chart && helm.version && helm.url) {
       getChartValues(helm).then((re) => {
-        this.setState({ values: re, helm: helm, loading: false });
+        this.setState({ values: re.BusinessCode ? undefined : re, helm: helm, loading: false });
       });
     }
   };
@@ -99,10 +99,17 @@ class HelmValues extends Component<Props, State> {
     return newValues;
   };
 
+  renderHelmKey = (params?: { url: string; chart: string; version: string }) => {
+    if (!params) {
+      return '';
+    }
+    return params.url + params.chart + params.version;
+  };
+
   render() {
     const { helm } = this.props;
     const { values, loading, helm: stateHelm } = this.state;
-    if (helm != stateHelm) {
+    if (this.renderHelmKey(helm) != this.renderHelmKey(stateHelm)) {
       this.loadChartValues();
     }
     return (

--- a/src/extends/HelmValues/index.tsx
+++ b/src/extends/HelmValues/index.tsx
@@ -3,6 +3,8 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 import type { UIParam } from '../../interface/application';
 import KV from '../KV';
+import { getChartValues } from '../../api/repository';
+import { Loading } from '@b-design/ui';
 
 type Props = {
   value?: any;
@@ -12,6 +14,12 @@ type Props = {
   subParameters?: UIParam[];
   id: string;
   disabled: boolean;
+  helm?: {
+    url: string;
+    repoType: string;
+    chart: string;
+    version: string;
+  };
 };
 
 function setValues(target: any, value: any, key: string, keys: string[]) {
@@ -43,8 +51,36 @@ function getValues(target: any, key: string, newValues: any) {
   }
 }
 
-class HelmValues extends Component<Props> {
-  componentDidMount() {}
+type State = {
+  values?: any;
+  helm?: {
+    url: string;
+    chart: string;
+    version: string;
+  };
+  loading: boolean;
+};
+
+class HelmValues extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      loading: true,
+    };
+  }
+
+  componentDidMount() {
+    this.loadChartValues();
+  }
+
+  loadChartValues = () => {
+    const { helm } = this.props;
+    if (helm?.chart && helm.version && helm.url) {
+      getChartValues(helm).then((re) => {
+        this.setState({ values: re, helm: helm, loading: false });
+      });
+    }
+  };
 
   onChange = (values: any) => {
     let helmValues: any = {};
@@ -64,16 +100,24 @@ class HelmValues extends Component<Props> {
   };
 
   render() {
+    const { helm } = this.props;
+    const { values, loading, helm: stateHelm } = this.state;
+    if (helm != stateHelm) {
+      this.loadChartValues();
+    }
     return (
-      <KV
-        disabled={this.props.disabled}
-        onChange={this.onChange}
-        value={this.renderValue()}
-        additional={this.props.additional}
-        additionalParameter={this.props.additionalParameter}
-        subParameters={this.props.subParameters}
-        id={this.props.id}
-      />
+      <Loading visible={loading} style={{ width: '100%' }}>
+        <KV
+          disabled={this.props.disabled}
+          onChange={this.onChange}
+          value={this.renderValue()}
+          keyOptions={values}
+          additional={this.props.additional}
+          additionalParameter={this.props.additionalParameter}
+          subParameters={this.props.subParameters}
+          id={this.props.id}
+        />
+      </Loading>
     );
   }
 }

--- a/src/interface/application.ts
+++ b/src/interface/application.ts
@@ -61,11 +61,19 @@ export interface UIParam {
     colSpan: number;
   };
   disable?: boolean;
+  conditions?: ParamCondition[];
   subParameterGroupOption?: GroupOption[];
   additional?: boolean;
   additionalParameter?: UIParam;
   subParameters?: UIParam[];
   validate: UIParamValidate;
+}
+
+export interface ParamCondition {
+  jsonKey: string;
+  op?: '==' | 'in' | '!=';
+  value: any;
+  action?: 'disable' | 'enable';
 }
 
 export interface GroupOption {
@@ -314,4 +322,17 @@ export interface DefinitionBase {
 export interface TraitDefinitionSpec {
   podDisruptive?: boolean;
   appliesToWorkloads?: string[];
+}
+
+export interface ChartVersion {
+  name: string;
+  version: string;
+  description?: string;
+  apiVersion: string;
+  appVersion: string;
+  type?: string;
+  urls: string[];
+  created: string;
+  digest: string;
+  icon?: string;
 }

--- a/src/interface/env.ts
+++ b/src/interface/env.ts
@@ -11,7 +11,7 @@ export interface Env {
   alias?: string;
   description?: string;
   namespace: string;
-  targets: NameAlias[];
+  targets?: NameAlias[];
   project: NameAlias;
   createTime?: string;
   updateTime?: string;

--- a/src/pages/ApplicationList/components/AddAppDialog/index.tsx
+++ b/src/pages/ApplicationList/components/AddAppDialog/index.tsx
@@ -41,6 +41,7 @@ type State = {
   envs?: Env[];
   project?: string;
   visibleEnvDialog: boolean;
+  createLoading: boolean;
 };
 
 type Callback = (envName: string) => void;
@@ -63,6 +64,7 @@ class AppDialog extends React.Component<Props, State> {
       dialogStats: 'isBasic',
       envs: [],
       visibleEnvDialog: false,
+      createLoading: false,
     };
     this.field = new Field(this, {
       onChange: (name: string, value: string) => {
@@ -131,11 +133,13 @@ class AppDialog extends React.Component<Props, State> {
           properties: JSON.stringify(properties),
         },
       };
+      this.setState({ createLoading: true });
       createApplication(params).then((res) => {
         if (res) {
           Message.success(<Translation>create application success</Translation>);
           this.props.onOK(name);
         }
+        this.setState({ createLoading: false });
       });
     });
   };
@@ -252,7 +256,7 @@ class AppDialog extends React.Component<Props, State> {
   };
 
   extButtonList = () => {
-    const { dialogStats } = this.state;
+    const { dialogStats, createLoading } = this.state;
     const { onClose } = this.props;
     if (dialogStats === 'isBasic') {
       return (
@@ -282,7 +286,7 @@ class AppDialog extends React.Component<Props, State> {
           >
             <Translation>Previous</Translation>
           </Button>
-          <Button type="primary" onClick={this.onSubmit}>
+          <Button loading={createLoading} type="primary" onClick={this.onSubmit}>
             <Translation>Create</Translation>
           </Button>
         </div>

--- a/src/pages/EnvPage/components/EnvDialog/index.tsx
+++ b/src/pages/EnvPage/components/EnvDialog/index.tsx
@@ -39,7 +39,7 @@ class EnvDialog extends React.Component<Props, State> {
     const { envItem, isEdit } = this.props;
     if (envItem && isEdit) {
       const { name, alias, description, targets, namespace, project } = envItem;
-      const targetNames = targets.map((target) => {
+      const targetNames = targets?.map((target) => {
         return target.name;
       });
 

--- a/src/pages/EnvPage/components/List/index.tsx
+++ b/src/pages/EnvPage/components/List/index.tsx
@@ -6,6 +6,7 @@ import locale from '../../../../utils/locale';
 import type { Env, NameAlias } from '../../../../interface/env';
 import { deleteEnv } from '../../../../api/env';
 import { Link } from 'dva/router';
+import { If } from 'tsx-control-statements/components';
 const { Group: TagGroup } = Tag;
 
 type Props = {
@@ -106,32 +107,34 @@ class TableList extends Component<Props> {
         cell: (v: string, i: number, record: Env) => {
           return (
             <div>
-              <a
-                onClick={() => {
-                  Dialog.confirm({
-                    type: 'confirm',
-                    content: (
-                      <Translation>
-                        Unrecoverable after deletion, are you sure to delete it?
-                      </Translation>
-                    ),
-                    onOk: () => {
-                      this.onDelete(record);
-                    },
-                    locale: locale.Dialog,
-                  });
-                }}
-              >
-                <Translation>Remove</Translation>
-              </a>
-              <a
-                className="margin-left-10"
-                onClick={() => {
-                  this.onEdit(record);
-                }}
-              >
-                <Translation>Edit</Translation>
-              </a>
+              <If condition={record.targets?.length}>
+                <a
+                  onClick={() => {
+                    Dialog.confirm({
+                      type: 'confirm',
+                      content: (
+                        <Translation>
+                          Unrecoverable after deletion, are you sure to delete it?
+                        </Translation>
+                      ),
+                      onOk: () => {
+                        this.onDelete(record);
+                      },
+                      locale: locale.Dialog,
+                    });
+                  }}
+                >
+                  <Translation>Remove</Translation>
+                </a>
+                <a
+                  className="margin-left-10"
+                  onClick={() => {
+                    this.onEdit(record);
+                  }}
+                >
+                  <Translation>Edit</Translation>
+                </a>
+              </If>
             </div>
           );
         },

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -116,3 +116,15 @@ export function getLink(endpointObj: Endpoint) {
   }
   return protocol + '://' + host + port + path;
 }
+
+export function getValue(key: string, value: any): any {
+  if (key.indexOf('.') > -1) {
+    const currentKey: string = key.substring(0, key.indexOf('.'));
+    const nextKey: string = key.substring(key.indexOf('.') + 1);
+    return getValue(nextKey, value[currentKey]);
+  }
+  if (!value) {
+    return null;
+  }
+  return value[key];
+}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

1. Support conditions in `ui schema` render. Ref oam-dev/kubevela#3461 
2. New some extend components about helm.
  * HelmRepoSelect
  * HelmChartSelect： Must have fields `url` 
  * HelmChartVersionSelect： Must have fields `url` and `chart`
  * HelmValues: Must have fields `url` 、`chart` and `version`.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.