### PR TITLE
Fix: component EnvBindPlanDialog get wrong envs

### DIFF
--- a/src/layout/Application/components/AddAndEditEnvBind/index.tsx
+++ b/src/layout/Application/components/AddAndEditEnvBind/index.tsx
@@ -53,7 +53,7 @@ class EnvBindPlanDialog extends Component<Props, State> {
     const { applicationDetail, envbinding } = this.props;
     if (applicationDetail) {
       //Temporary logic
-      getEnvs({ project: 'default', page: 0 }).then((re) => {
+      getEnvs({ project: applicationDetail.project?.name || 'default', page: 0 }).then((re) => {
         const existEnvs =
           envbinding?.map((eb) => {
             return eb.name;


### PR DESCRIPTION
Signed-off-by: xianyue <13651133+xianyue390348@users.noreply.github.com>

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes # Fix: component EnvBindPlanDialog get wrong envs

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
