### PR TITLE
Fix: Fallback local language to en if selected language does not exist 

### DIFF
--- a/src/utils/locale.tsx
+++ b/src/utils/locale.tsx
@@ -182,7 +182,7 @@ class SingletonLocal {
   public getLocal() {
     return () => {
       const language = getLanguage();
-      return this.local[language];
+      return this.local[language] ?? this.local.en;
     };
   }
 }


### PR DESCRIPTION
### Description of your changes
Currently only en and zh are the only supported languages. 
If for example in reason of other browser language settings, the locales doesn't exist and the ui is not visible (after login).
As workaround it is possible to change the browser language (bad way).

The solution is to add a fallback language.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #488":

-->

Fixes #488

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review. (ignore untouched file src/locals/Zh/zh.json)
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
